### PR TITLE
Add Tor Wi‑Fi access point installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,111 @@
-# toratora
+# ToraTora
+
+ToraTora turns a Raspberry Pi into a Wi‑Fi access point whose traffic is transparently routed through the Tor network. Clients connecting to the Pi's WLAN are forced through Tor with no clearnet escape path.
+
+## Overview
+* **Torified AP** – Every TCP connection and DNS query from Wi‑Fi clients is redirected into Tor's `TransPort`/`DNSPort`.
+* **Threat model** – Designed for users who trust the local network but wish to hide destination IP information from their ISP or local observers. It does **not** anonymize traffic leaving Tor nor protect against malicious Tor exit nodes.
+
+## Architecture
+```mermaid
+graph TD
+  subgraph Clients
+    C1[Phone]
+    C2[Laptop]
+  end
+  C1 -->|wlan0 10.10.0.0/24| PI[Raspberry Pi]
+  C2 -->|wlan0 10.10.0.0/24| PI
+  PI -->|Tor 9040/9053| Tor[Tor Network]
+  PI -->|eth0 DHCP| WAN[Internet]
+```
+
+## Prerequisites
+* Raspberry Pi 4 (or compatible with onboard Wi‑Fi)
+* Raspberry Pi OS Bullseye or Bookworm
+* Internet connectivity on `eth0`
+* Keyboard/console or SSH access with sudo privileges
+
+## Quick start
+```bash
+curl -L https://example.com/setup-tor-ap.sh -o setup-tor-ap.sh
+sudo bash setup-tor-ap.sh --ssid toratora --psk "YourStrongPass" --country US --subnet 10.10.0.0/24 --channel 6
+```
+Expected banner:
+```
+ _____              _____
+|_   _|__  _ __ __ |_   _|__  _ __ __ _
+  | |/ _ \| '__/ _` || |/ _ \| '__/ _` |
+  | | (_) | | | (_| || | (_) | | | (_| |
+  |_|\___/|_|  \__,_||_|\___/|_|  \__,_|
+      ToraTora - Tor Wi-Fi Access Point installer
+```
+
+## Inputs & defaults
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--ssid` | `toratora` | SSID broadcast by hostapd |
+| `--psk` | _prompted_ | WPA2 passphrase (min 12 chars) |
+| `--country` | `US` | Wi‑Fi regulatory domain |
+| `--subnet` | `10.10.0.0/24` | LAN subnet, gateway `.1` |
+| `--channel` | `6` | 2.4 GHz channel |
+| `--dry-run` | n/a | Show actions without applying |
+| `--revert` | n/a | Restore backups and disable services |
+| `--quiet` | n/a | Suppress non‑essential logs |
+| `--no-color` | n/a | Disable ANSI colours |
+
+## What the script changes
+* Installs packages: `tor`, `hostapd`, `dnsmasq`, `jq`, and firewall tooling (`nftables` on Bookworm, `iptables-nft` on Bullseye).
+* Configures static IP for `wlan0` and enables IPv4 forwarding, disables IPv6.
+* Writes configs:
+  * `/etc/hostapd/hostapd.conf`
+  * `/etc/dnsmasq.d/tor-ap.conf`
+  * `/etc/tor/torrc`
+  * `/etc/nftables.conf` or `/etc/iptables/rules.v4`
+* Enables services: `nftables`/`netfilter-persistent`, `dnsmasq`, `tor`, `hostapd`.
+* All modified files are backed up with a `.toratora.bak.*` suffix.
+
+## Validation
+1. Ensure the AP is up:
+   ```bash
+   ip addr show wlan0
+   ```
+2. Verify Tor ports:
+   ```bash
+   sudo ss -lnptu | grep -E '9053|9040'
+   torsocks curl https://check.torproject.org/api/ip
+   ```
+3. Connect a Wi‑Fi client and browse [check.torproject.org](https://check.torproject.org) to confirm `IsTor: true`.
+
+## Troubleshooting
+* **Wi‑Fi blocked** – run `rfkill list` and `rfkill unblock wifi`.
+* **hostapd fails** – check `journalctl -u hostapd` for channel/country errors.
+* **NetworkManager vs dhcpcd** – ensure only one manages `wlan0`.
+* **Tor not listening** – check `/var/log/syslog` and `journalctl -u tor`.
+* **DNS leaks** – verify firewall rules, ensure IPv6 disabled.
+* **IPv6** – disabled by default; re‑enable by editing `/etc/sysctl.d/99-tor-ap.conf`.
+
+## Security considerations
+* Use only on networks you control.
+* WPA2 passphrase should be strong; change defaults.
+* Tor exit nodes can observe unencrypted traffic – use HTTPS.
+* No clearnet NAT path is provided; all traffic goes through Tor.
+* Logs remain on the Pi; inspect `/var/log` and consider log rotation.
+
+## Customization
+* Change `--subnet`, `--channel`, or `--country` to suit your environment.
+* 5 GHz requires compatible hardware and adjusted `hw_mode`/channel.
+* Alternate interface names (e.g., USB Wi‑Fi) can be set by editing the script variables.
+* To enable IPv6 for clients, remove the disable lines from `99-tor-ap.conf` and extend firewall rules.
+
+## Support matrix
+| OS | Firewall |
+|----|----------|
+| Bookworm | `nftables` |
+| Bullseye | `iptables-nft` + `netfilter-persistent` |
+
+## Uninstall / Revert
+Run the script with `--revert` to restore backed up configurations and disable services.
+Manual cleanup: remove `/etc/hostapd/hostapd.conf`, `/etc/dnsmasq.d/tor-ap.conf`, `/etc/tor/torrc`, and firewall rules; uninstall packages if desired.
+
+## License
+MIT. Inspired by the guide at [pimylifeup.com](https://pimylifeup.com/raspberry-pi-tor-access-point/).

--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# ToraTora - Raspberry Pi Tor Access Point installer
+# Usage: sudo ./setup-tor-ap.sh --ssid "toratora" --psk "YourStrongPass" --country US --subnet 10.10.0.0/24 --channel 6 [--dry-run] [--revert] [--quiet] [--no-color]
+
+set -euo pipefail
+
+SSID="toratora"
+PSK=""
+COUNTRY="US"
+SUBNET="10.10.0.0/24"
+CHANNEL="6"
+DRY_RUN=0
+REVERT=0
+QUIET=0
+NO_COLOR=0
+
+TOTAL_STEPS=10
+CURRENT_STEP=0
+
+if [ -t 1 ]; then
+  IS_TTY=1
+else
+  IS_TTY=0
+fi
+
+if [ "$IS_TTY" -eq 1 ] && [ "$NO_COLOR" -eq 0 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  BLUE='\033[0;34m'
+  BOLD='\033[1m'
+  RESET='\033[0m'
+else
+  RED='' ; GREEN='' ; YELLOW='' ; BLUE='' ; BOLD='' ; RESET=''
+fi
+
+log(){ local lvl="$1"; shift; local col="$1"; shift||true; local msg="$*"; [ "$QUIET" -eq 1 ] && [ "$lvl" = INFO ] && return; printf "%b%s%b\n" "$col" "$msg" "$RESET"; }
+info(){ log INFO "$BLUE" "$*"; }
+success(){ log INFO "$GREEN" "$*"; }
+warn(){ log WARN "$YELLOW" "$*"; }
+error(){ log ERROR "$RED" "$*"; }
+
+step(){ CURRENT_STEP=$((CURRENT_STEP+1)); [ "$QUIET" -eq 0 ] && printf "%b▶ [%d/%d] %s%b\n" "$BOLD" "$CURRENT_STEP" "$TOTAL_STEPS" "$1" "$RESET"; }
+
+spinner(){ local pid=$1; local spin='-\|/'; local i=0; [ "$QUIET" -eq 1 ] && { wait "$pid"; return; }; while kill -0 "$pid" 2>/dev/null; do printf "\r%s" "${spin:i++%4:1}"; sleep 0.1; done; printf "\r"; wait "$pid"; }
+run_cmd(){ "$@" & spinner $!; }
+
+usage(){ cat <<USAGE
+Usage: sudo ./setup-tor-ap.sh --ssid "toratora" --psk "YourStrongPass" --country US --subnet 10.10.0.0/24 --channel 6 [--dry-run] [--revert] [--quiet] [--no-color]
+USAGE
+exit 1; }
+
+parse_args(){ while [[ $# -gt 0 ]]; do case "$1" in --ssid) SSID="$2"; shift 2;; --psk) PSK="$2"; shift 2;; --country) COUNTRY="$2"; shift 2;; --subnet) SUBNET="$2"; shift 2;; --channel) CHANNEL="$2"; shift 2;; --dry-run) DRY_RUN=1; shift;; --revert) REVERT=1; shift;; --quiet) QUIET=1; shift;; --no-color) NO_COLOR=1; shift;; -h|--help) usage;; *) error "Unknown argument: $1"; usage;; esac; done; if [ -z "$PSK" ] && [ "$REVERT" -eq 0 ]; then read -rp "Enter WPA2 passphrase (min 12 chars): " PSK; fi; if [ ${#PSK} -lt 12 ] && [ "$REVERT" -eq 0 ]; then error "Passphrase must be at least 12 characters"; exit 1; fi; }
+
+backup_file(){ local f="$1"; [ -f "$f" ] && { local b="${f}.toratora.bak.$(date +%Y%m%d%H%M%S)"; cp "$f" "$b"; BACKUPS+=("$b"); }; }
+write_file(){ local p="$1"; local c="$2"; [ "$DRY_RUN" -eq 1 ] && { info "Would write $p"; return; }; backup_file "$p"; printf "%s" "$c" > "$p"; }
+append_if_missing(){ local l="$1" f="$2"; [ "$DRY_RUN" -eq 1 ] && { info "Would ensure line in $f: $l"; return; }; grep -qxF "$l" "$f" 2>/dev/null || echo "$l" >> "$f"; }
+
+BACKUPS=()
+
+revert_changes(){ warn "Reverting configuration..."; for b in "${BACKUPS[@]}"; do local o="${b%.toratora.bak.*}"; [ -f "$b" ] && mv "$b" "$o"; done; systemctl disable --now hostapd dnsmasq tor nftables 2>/dev/null || true; success "Revert complete"; }
+
+print_banner(){ [ "$QUIET" -eq 1 ] && return; cat <<'BANNER'
+ _____              _____
+|_   _|__  _ __ __ |_   _|__  _ __ __ _
+  | |/ _ \| '__/ _` || |/ _ \| '__/ _` |
+  | | (_) | | | (_| || | (_) | | | (_| |
+  |_|\___/|_|  \__,_||_|\___/|_|  \__,_|
+      ToraTora - Tor Wi-Fi Access Point installer
+BANNER
+}
+
+preflight_checks(){ step "Preflight checks"; [ "$EUID" -ne 0 ] && { error "Run as root"; exit 1; }; systemd-detect-virt --quiet && { error "Virtual environment detected"; exit 1; }; grep -qi 'Raspberry Pi' /proc/device-tree/model || { error "Not a Raspberry Pi"; exit 1; }; ip link show eth0 >/dev/null 2>&1 || { error "eth0 missing"; exit 1; }; ip link show wlan0 >/dev/null 2>&1 || { error "wlan0 missing"; exit 1; }; ip link show eth0 | grep -q "state UP" || { error "eth0 down"; exit 1; }; curl -s --head https://check.torproject.org >/dev/null || { error "No Internet connectivity on eth0"; exit 1; }; . /etc/os-release; OS_RELEASE="$VERSION_CODENAME"; [ "$OS_RELEASE" = bookworm ] && FIREWALL_TOOL="nftables" || FIREWALL_TOOL="iptables-nft"; success "Preflight checks passed"; }
+install_packages(){ step "Install packages"; local pkgs=(tor hostapd dnsmasq jq); if [ "$FIREWALL_TOOL" = "nftables" ]; then pkgs+=(nftables); else pkgs+=(iptables iptables-persistent netfilter-persistent); fi; if [ "$DRY_RUN" -eq 1 ]; then info "Would install: ${pkgs[*]}"; return; fi; run_cmd apt-get update -y; run_cmd apt-get install -y "${pkgs[@]}"; }
+
+configure_network(){
+  step "Configure network"
+  if command -v raspi-config >/dev/null; then
+    if [ "$DRY_RUN" -eq 1 ]; then
+      info "Would set Wi-Fi country to $COUNTRY"
+    else
+      run_cmd raspi-config nonint do_wifi_country "$COUNTRY"
+    fi
+  fi
+  local sysctl_conf=/etc/sysctl.d/99-tor-ap.conf
+  local sysctl_content="net.ipv4.ip_forward=1\nnet.ipv6.conf.all.disable_ipv6=1\nnet.ipv6.conf.default.disable_ipv6=1"
+  write_file "$sysctl_conf" "$sysctl_content"
+  [ "$DRY_RUN" -eq 0 ] && run_cmd sysctl -p "$sysctl_conf"
+  if [ "$OS_RELEASE" = bookworm ]; then
+    if nmcli -t -f NAME c show torap-wlan0 >/dev/null 2>&1; then
+      :
+    elif [ "$DRY_RUN" -eq 1 ]; then
+      info "Would create nmcli connection torap-wlan0"
+    else
+      run_cmd nmcli con add type wifi ifname wlan0 con-name torap-wlan0 autoconnect yes ssid "$SSID"
+      run_cmd nmcli con modify torap-wlan0 802-11-wireless.mode ap 802-11-wireless.band bg 802-11-wireless.channel "$CHANNEL" ipv4.method manual ipv4.addresses "10.10.0.1/24" ipv4.gateway "" ipv4.dhcp-hostname "" ipv6.method ignore
+      run_cmd nmcli con modify torap-wlan0 wifi-sec.key-mgmt wpa-psk wifi-sec.psk "$PSK"
+    fi
+  else
+    append_if_missing "interface wlan0" /etc/dhcpcd.conf
+    append_if_missing "static ip_address=10.10.0.1/24" /etc/dhcpcd.conf
+    append_if_missing "nohook wpa_supplicant" /etc/dhcpcd.conf
+  fi
+  success "Network configured"
+}
+
+configure_hostapd(){ step "Configure hostapd"; local conf=/etc/hostapd/hostapd.conf; local content="interface=wlan0\nssid=$SSID\ncountry_code=$COUNTRY\nhw_mode=g\nchannel=$CHANNEL\nieee80211n=1\nwmm_enabled=1\nwpa=2\nwpa_key_mgmt=WPA-PSK\nrsn_pairwise=CCMP\nwpa_passphrase=$PSK"; write_file "$conf" "$content"; append_if_missing "DAEMON_CONF=\"$conf\"" /etc/default/hostapd; success "hostapd configured"; }
+
+configure_dnsmasq(){ step "Configure dnsmasq"; local conf=/etc/dnsmasq.d/tor-ap.conf; local content="interface=wlan0\nbind-interfaces\ndhcp-range=10.10.0.50,10.10.0.200,255.255.255.0,12h\ndhcp-option=option:router,10.10.0.1\nport=0"; write_file "$conf" "$content"; success "dnsmasq configured"; }
+
+configure_tor(){ step "Configure Tor"; local conf=/etc/tor/torrc; local content="Log notice syslog\nUser debian-tor\nDataDirectory /var/lib/tor\nAutomapHostsOnResolve 1\nVirtualAddrNetworkIPv4 10.192.0.0/10\nTransPort 9040\nDNSPort 9053\nAvoidDiskWrites 1"; write_file "$conf" "$content"; success "Tor configured"; }
+
+configure_firewall(){ step "Configure firewall"; if [ "$FIREWALL_TOOL" = nftables ]; then local conf=/etc/nftables.conf; local content="table inet torap {\n  chains {\n    input {\n      type filter hook input priority 0;\n      ct state established,related accept\n      iif lo accept\n      iifname \\\"wlan0\\\" udp dport {67,68} accept\n      iifname \\\"wlan0\\\" tcp dport 9040 accept\n      iifname \\\"wlan0\\\" udp dport 9053 accept\n      counter drop\n    }\n    prerouting {\n      type nat hook prerouting priority -100;\n      iifname \\\"wlan0\\\" meta skuid != debian-tor tcp redirect to :9040\n      iifname \\\"wlan0\\\" udp dport 53 redirect to :9053\n    }\n    output {\n      type filter hook output priority 0;\n      ct state established,related accept\n      meta skuid debian-tor accept\n      accept\n    }\n  }\n}"; write_file "$conf" "$content"; [ "$DRY_RUN" -eq 0 ] && { run_cmd systemctl enable nftables; run_cmd nft -f "$conf"; }; else local rules=/etc/iptables/rules.v4; local content="*nat\n:PREROUTING ACCEPT [0:0]\n:INPUT ACCEPT [0:0]\n:OUTPUT ACCEPT [0:0]\n:POSTROUTING ACCEPT [0:0]\n-A PREROUTING -i wlan0 -p tcp -m owner ! --uid-owner debian-tor -j REDIRECT --to-ports 9040\n-A PREROUTING -i wlan0 -p udp --dport 53 -j REDIRECT --to-ports 9053\nCOMMIT\n*filter\n:INPUT DROP [0:0]\n:FORWARD DROP [0:0]\n:OUTPUT ACCEPT [0:0]\n-A INPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n-A INPUT -i lo -j ACCEPT\n-A INPUT -i wlan0 -p udp --dport 67:68 -j ACCEPT\n-A INPUT -i wlan0 -p tcp --dport 9040 -j ACCEPT\n-A INPUT -i wlan0 -p udp --dport 9053 -j ACCEPT\n-A OUTPUT -m state --state ESTABLISHED,RELATED -j ACCEPT\n-A OUTPUT -m owner --uid-owner debian-tor -j ACCEPT\n-A OUTPUT -j ACCEPT\nCOMMIT"; write_file "$rules" "$content"; [ "$DRY_RUN" -eq 0 ] && { run_cmd systemctl enable netfilter-persistent; run_cmd netfilter-persistent save; }; fi; success "Firewall configured"; }
+
+enable_services(){ step "Enable services"; [ "$DRY_RUN" -eq 1 ] && { info "Would enable services"; return; }; if [ "$FIREWALL_TOOL" = nftables ]; then run_cmd systemctl enable nftables; run_cmd systemctl start nftables; else run_cmd systemctl enable netfilter-persistent; run_cmd systemctl start netfilter-persistent; fi; run_cmd systemctl enable dnsmasq; run_cmd systemctl enable tor; run_cmd systemctl enable hostapd; run_cmd systemctl start dnsmasq; run_cmd systemctl start tor; run_cmd systemctl start hostapd; success "Services enabled"; }
+
+summary(){ cat <<EOF
+
+╔════════════════════════════════════╗
+║  ✅ Setup Complete                  ║
+╠════════════════════════════════════╣
+║ SSID: $SSID
+║ Subnet: $SUBNET
+║ Firewall: $FIREWALL_TOOL
+║ Services: hostapd, dnsmasq, tor
+║ Verify: torsocks curl https://check.torproject.org/api/ip
+╚════════════════════════════════════╝
+Use only on networks you control and in accordance with local laws.
+EOF
+}
+
+main(){ parse_args "$@"; print_banner; if [ "$REVERT" -eq 1 ]; then revert_changes; exit 0; fi; preflight_checks; install_packages; configure_network; configure_hostapd; configure_dnsmasq; configure_tor; configure_firewall; enable_services; summary; }
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `setup-tor-ap.sh` to configure Raspberry Pi as Tor Wi‑Fi access point
- document usage, architecture, and validation steps in README
- fix banner to display "ToraTora"

## Testing
- `bash -n setup-tor-ap.sh`
- `shellcheck setup-tor-ap.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f7672a3c4832da1e275e0c0062a00