### PR TITLE
fix: allow firewall configuration to complete

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -146,7 +146,7 @@ configure_firewall(){
   if [ "$FIREWALL_TOOL" = nftables ]; then
     local conf=/etc/nftables.conf
     local content
-    read -r -d '' content <<'EOF'
+    read -r -d '' content <<'EOF' || true
 table inet torap {
   chains {
     input {
@@ -177,7 +177,7 @@ EOF
   else
     local rules=/etc/iptables/rules.v4
     local content
-    read -r -d '' content <<'EOF'
+    read -r -d '' content <<'EOF' || true
 *nat
 :PREROUTING ACCEPT [0:0]
 :INPUT ACCEPT [0:0]


### PR DESCRIPTION
## Summary
- avoid premature exit in configure_firewall by allowing here-doc `read` to succeed

## Testing
- `bash -n setup-tor-ap.sh`
- `shellcheck setup-tor-ap.sh`

------
https://chatgpt.com/codex/tasks/task_e_689f8198994c832d865a9242dd769553