### PR TITLE
Avoid dnsmasq errors by storing backups elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Expected banner:
   * `/etc/tor/torrc`
   * `/etc/nftables.conf` or `/etc/iptables/rules.v4`
 * Enables services: `nftables`/`netfilter-persistent`, `dnsmasq`, `tor`, `hostapd`.
-* All modified files are backed up with a `.toratora.bak.*` suffix.
+* All modified files are backed up to `/var/backups/toratora` with a `.toratora.<timestamp>.bak` suffix.
 
 ## Validation
 1. Ensure the AP is up:


### PR DESCRIPTION
## Summary
- Store configuration backups in `/var/backups/toratora` to prevent services from reading them
- Update revert logic for new backup locations
- Document backup path in README

## Testing
- `bash -n setup-tor-ap.sh`
- `shellcheck setup-tor-ap.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f8751e21c832d838521c68a1c7749