### PR TITLE
Handle raspi-config failure in tor AP setup script

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -157,7 +157,9 @@ configure_network(){
     if [ "$DRY_RUN" -eq 1 ]; then
       info "Would set Wi-Fi country to $COUNTRY"
     else
-      run_cmd raspi-config nonint do_wifi_country "$COUNTRY"
+      if ! run_cmd raspi-config nonint do_wifi_country "$COUNTRY"; then
+        warn "Failed to set Wi-Fi country to $COUNTRY"
+      fi
     fi
   fi
   local sysctl_conf=/etc/sysctl.d/99-tor-ap.conf


### PR DESCRIPTION
## Summary
- prevent setup script from aborting when `raspi-config` fails to set Wi-Fi country
- log a warning instead of stopping execution

## Testing
- `bash -n setup-tor-ap.sh`
- `./setup-tor-ap.sh --dry-run --ssid test --psk "123456789012" --country US --subnet 10.10.0.0/24 --channel 6` *(fails: Virtual environment detected)*

------
https://chatgpt.com/codex/tasks/task_e_68a5cc5cbcb4832db21ed6caa3db744b