### PR TITLE
Add Tor AP setup script and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,155 @@
+# Raspberry Pi Tor Wi-Fi Access Point
+
+A one-command setup that turns a Raspberry Pi running Raspberry Pi OS Bookworm into a Wi-Fi hotspot whose clients are transparently routed through the Tor anonymity network. It is idempotent, reversible, and uses NetworkManager for Wi-Fi configuration.
+
+## At-a-glance Features
+- One-command setup script
+- Wi-Fi access point via NetworkManager
+- Transparent Tor routing (TransPort/DNSPort)
+- Idempotent & reversible configuration
+- Works on Raspberry Pi OS Bookworm
+
+## Architecture & Network Diagrams
+
+```mermaid
+graph TD
+  Client -->|Wi-Fi| AP[wlan0]
+  AP -->|PREROUTING| NAT[iptables]
+  NAT --> Tor
+  Tor -->|eth0| Internet
+```
+
+```
+Client --> wlan0 (AP) --> iptables PREROUTING --> Tor (TransPort/DNSPort) --> eth0 --> Internet
+```
+
+```mermaid
+graph LR
+  subgraph WLAN [192.168.220.0/24]
+    ClientIP((Clients)) -- TCP/UDP53 --> AP_IP[192.168.220.1]
+  end
+  AP_IP -- 9040 & 53 --> Tor
+```
+
+```
++-----------------------+
+| Clients 192.168.220.x |
++-----------------------+
+           |
+           | wifi
+           v
++------------------------+
+| AP wlan0 192.168.220.1 |
++------------------------+
+           |
+      iptables PREROUTING
+           |
+           v
++----- Tor TransPort 9040 / DNSPort 53 ----+
+           |
+           v
+        eth0 -> Internet
+```
+
+## How It Works (Deep Dive)
+NetworkManager creates a Wi-Fi hotspot on `wlan0` with the static gateway `192.168.220.1`. `iptables` PREROUTING rules redirect all TCP SYN packets and UDP DNS queries from clients into Tor's `TransPort` and `DNSPort`. Tor then handles outbound connections over `eth0`. No masquerading is needed because Tor manages the egress routing. Non-TCP protocols (other than UDP/53) are not proxied and will fail.
+
+## Security Considerations
+- Change the default SSID and pre-shared key immediately.
+- Keep the system updated.
+- Misconfiguration may expose traffic; Tor exit policies do not guarantee safety.
+- Logging in to personal accounts still reveals identity; do not route illegal traffic.
+- Optional hardening: disable password SSH, use key authentication, rotate the PSK, and restrict management to Ethernet.
+
+## Prerequisites
+- Raspberry Pi with Wi-Fi, SD card, power, and wired internet on `eth0`.
+- Raspberry Pi OS **Bookworm** (32- or 64-bit).
+- NetworkManager and Tor packages available via `apt`.
+
+## Raspberry Pi Setup (from blank SD to first boot)
+1. Flash Raspberry Pi OS with Raspberry Pi Imager.
+2. (Optional) enable SSH and set Wi-Fi country in the Imager.
+3. Boot the Pi, change the default password.
+4. Update the system:
+   ```bash
+   sudo apt update && sudo apt -y upgrade
+   ```
+5. Verify NetworkManager:
+   ```bash
+   nmcli --version
+   ```
+6. Confirm interface names:
+   ```bash
+   ip link
+   ```
+7. Set timezone/locale/keyboard as needed.
+
+## Script Installation & Usage
+Download or clone this repository, then:
+```bash
+chmod +x setup-tor-ap.sh
+sudo SSID="MyTorAP" PSK="StrongPass123!" bash ./setup-tor-ap.sh
+```
+Environment variables:
+- `AP_IFACE`, `WAN_IFACE`, `AP_SUBNET`, `AP_GATEWAY`, `SSID`, `PSK`, `TOR_TRANS_PORT`, `TOR_DNS_PORT`
+
+Flags:
+- `--dry-run` – show actions without making changes
+- `--uninstall` – revert all changes
+
+Backups: `/etc/tor/torrc.bak` is created once. Sysctl and iptables files are modified idempotently.
+
+## What the Script Changes
+- `/etc/tor/torrc` – adds TransPort/DNSPort, Automap, logging
+- `/var/log/tor/notices.log`
+- `/etc/sysctl.d/99-tor-ap.conf` – enables IPv4 forwarding
+- `/etc/iptables/rules.v4` (and `/etc/iptables.ipv4.nat` if present) – persists NAT redirects
+- NetworkManager connection `tor-ap`
+
+Services: enables `tor` and restores iptables at boot.
+
+## Verification Checklist
+- `nmcli dev` shows hotspot active on `wlan0` with IP `192.168.220.1`.
+- `sudo systemctl status tor` is “active (running)”.
+- `sudo iptables -t nat -L -n -v` lists the three redirect rules.
+- On a client connected to the AP:
+  - DNS queries resolve.
+  - `curl https://check.torproject.org/` shows Tor usage.
+  - Optionally on the Pi: `torify curl ifconfig.me` returns a Tor exit IP.
+
+## Troubleshooting
+- **Tor bind errors**: ensure the hotspot is up before Tor starts; the script retries for 30s.
+- **No internet**: confirm `eth0` has DHCP connectivity (`ping -c1 1.1.1.1`).
+- **DNS fails**: verify the UDP/53 PREROUTING rule and the `DNSPort` line in `torrc`.
+- **Wrong interface names**: override with environment variables.
+- **iptables not persisting**: reinstall `iptables`/`iptables-persistent`.
+- **Wi-Fi country issues**: set the regulatory domain with `raspi-config`.
+
+## Uninstall / Revert
+```bash
+sudo bash ./setup-tor-ap.sh --uninstall
+```
+Removes the NetworkManager hotspot, Tor configuration, NAT rules, and sysctl settings, restoring backups where possible.
+
+## FAQ
+- **Why not nftables?** Bookworm's `iptables-nft` provides compatibility; the script uses classic `iptables` for parity with common guides.
+- **Can I change the subnet?** Yes, set `AP_SUBNET`/`AP_GATEWAY` environment variables.
+- **Does it route UDP?** Only DNS (UDP/53). Other UDP protocols are unsupported through Tor TransPort.
+- **How do I customize SSID/PSK?** Set `SSID` and `PSK` before running the script.
+
+## Ethics & Legal
+Use Tor responsibly. Ensure that all traffic routed through this access point complies with local laws. The authors assume no liability for misuse.
+
+## Maintenance
+- Keep packages updated: `sudo apt update && sudo apt -y upgrade`.
+- Rotate the Wi-Fi password and re-run the script to apply changes.
+- Re-running the script is safe; it is idempotent.
+
+## Changelog & License
+- v1.0.0 – Initial release
+
+Released under the MIT License.
+
+## Credits
+Inspired by PiMyLifeUp’s “Tor Access Point” and “Raspberry Pi Access Point” guides.
+

--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Raspberry Pi Tor Access Point setup script
+# Configures a Raspberry Pi running Raspberry Pi OS Bookworm with NetworkManager
+# to operate as a Wi-Fi access point whose clients are transparently routed
+# through Tor.
+
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+#===========================
+# Configuration (override via environment)
+AP_IFACE=${AP_IFACE:-wlan0}
+WAN_IFACE=${WAN_IFACE:-eth0}
+AP_SUBNET=${AP_SUBNET:-192.168.220.0/24}
+AP_GATEWAY=${AP_GATEWAY:-192.168.220.1}
+SSID=${SSID:-TorAP}
+PSK=${PSK:-ChangeMe1234}
+TOR_TRANS_PORT=${TOR_TRANS_PORT:-9040}
+TOR_DNS_PORT=${TOR_DNS_PORT:-53}
+#===========================
+
+DRY_RUN=0
+UNINSTALL=0
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    --uninstall) UNINSTALL=1 ;;
+    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
+
+run_cmd() {
+  echo "+ $*"
+  if ((DRY_RUN)); then
+    return 0
+  fi
+  eval "$@"
+}
+
+require_root() {
+  if [[ $EUID -ne 0 ]]; then
+    echo "This script must be run as root" >&2
+    exit 1
+  fi
+}
+
+check_bookworm() {
+  if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    if [[ ${VERSION_CODENAME:-} != "bookworm" ]]; then
+      echo "This script supports Raspberry Pi OS Bookworm only" >&2
+      exit 1
+    fi
+  else
+    echo "/etc/os-release not found" >&2
+    exit 1
+  fi
+}
+
+ensure_packages() {
+  local packages=(tor iptables iptables-persistent qrencode network-manager)
+  run_cmd "apt-get update"
+  run_cmd "apt-get -y upgrade"
+  run_cmd "apt-get -y install ${packages[*]}"
+}
+
+ensure_sysctl() {
+  local file=/etc/sysctl.d/99-tor-ap.conf
+  if [[ ! -f $file ]]; then
+    run_cmd "echo 'net.ipv4.ip_forward=1' > $file"
+  else
+    grep -Fqx 'net.ipv4.ip_forward=1' "$file" || run_cmd "echo 'net.ipv4.ip_forward=1' >> $file"
+  fi
+  run_cmd "sysctl --system"
+}
+
+ensure_hotspot() {
+  if ! ip link show "$AP_IFACE" &>/dev/null; then
+    echo "Interface $AP_IFACE not found" >&2
+    exit 1
+  fi
+  local con_name="tor-ap"
+  if ! nmcli -t -f NAME connection show | grep -Fxq "$con_name"; then
+    run_cmd "nmcli dev wifi hotspot ifname '$AP_IFACE' con-name '$con_name' ssid '$SSID' password '$PSK'"
+  else
+    run_cmd "nmcli connection modify '$con_name' 802-11-wireless.ssid '$SSID' 802-11-wireless-security.psk '$PSK'"
+  fi
+  run_cmd "nmcli connection modify '$con_name' ipv4.addresses '$AP_GATEWAY/24' ipv4.method shared ipv4.gateway '$AP_GATEWAY'"
+  run_cmd "nmcli connection up '$con_name'"
+  if command -v qrencode &>/dev/null; then
+    echo "Hotspot QR code:"; qrencode -t ansiutf8 "WIFI:S:${SSID};T:WPA;P:${PSK};;" || true
+  fi
+}
+
+ensure_torrc() {
+  local torrc=/etc/tor/torrc
+  if [[ ! -f ${torrc}.bak ]]; then
+    run_cmd "cp '$torrc' '${torrc}.bak'"
+  fi
+  run_cmd "sed -i '/^TransListenAddress/d;/^DNSListenAddress/d' '$torrc'"
+  ensure_line "$torrc" "Log notice file /var/log/tor/notices.log"
+  ensure_line "$torrc" "VirtualAddrNetwork 10.192.0.0/10"
+  ensure_line "$torrc" "AutomapHostsSuffixes .onion,.exit"
+  ensure_line "$torrc" "AutomapHostsOnResolve 1"
+  ensure_line "$torrc" "TransPort ${AP_GATEWAY}:${TOR_TRANS_PORT}"
+  ensure_line "$torrc" "DNSPort ${AP_GATEWAY}:${TOR_DNS_PORT}"
+  run_cmd "install -m 0644 -o debian-tor -g debian-tor /dev/null /var/log/tor/notices.log"
+}
+
+ensure_line() {
+  local file=$1
+  local line=$2
+  grep -Fqx "$line" "$file" || run_cmd "echo '$line' >> '$file'"
+}
+
+ensure_iptables() {
+  iptables_rule "-t nat -A PREROUTING -i ${AP_IFACE} -p tcp --dport 22 -j REDIRECT --to-ports 22"
+  iptables_rule "-t nat -A PREROUTING -i ${AP_IFACE} -p udp --dport 53 -j REDIRECT --to-ports ${TOR_DNS_PORT}"
+  iptables_rule "-t nat -A PREROUTING -i ${AP_IFACE} -p tcp --syn -j REDIRECT --to-ports ${TOR_TRANS_PORT}"
+  run_cmd "iptables-save > /etc/iptables/rules.v4"
+  [[ -f /etc/iptables.ipv4.nat ]] && run_cmd "iptables-save > /etc/iptables.ipv4.nat"
+}
+
+iptables_rule() {
+  local rule=$1
+  if ! iptables ${rule/-A/-C} 2>/dev/null; then
+    run_cmd "iptables $rule"
+  fi
+}
+
+start_services() {
+  run_cmd "systemctl enable --now tor"
+  for i in {1..30}; do
+    if ip addr show "$AP_IFACE" | grep -q "$AP_GATEWAY"; then
+      run_cmd "systemctl restart tor"
+      break
+    fi
+    sleep 1
+  done
+}
+
+summary() {
+  echo "\nSSID: $SSID"
+  echo "Access Point IP: $AP_GATEWAY"
+  systemctl is-active --quiet tor && tor_status="active" || tor_status="inactive"
+  echo "Tor service: $tor_status"
+  echo "iptables NAT table:"; iptables -t nat -L -n -v | sed -n '1,120p'
+}
+
+uninstall() {
+  local torrc=/etc/tor/torrc
+  run_cmd "systemctl disable --now tor" || true
+  run_cmd "nmcli connection delete 'tor-ap'" || true
+  run_cmd "sed -i '/Log notice file \/var\/log\/tor\/notices.log/d;/VirtualAddrNetwork 10.192.0.0\/10/d;/AutomapHostsSuffixes .onion,.exit/d;/AutomapHostsOnResolve 1/d;/TransPort ${AP_GATEWAY}:${TOR_TRANS_PORT}/d;/DNSPort ${AP_GATEWAY}:${TOR_DNS_PORT}/d' '$torrc'"
+  [[ -f ${torrc}.bak ]] && run_cmd "mv '${torrc}.bak' '$torrc'"
+  iptables_unrule "-t nat -D PREROUTING -i ${AP_IFACE} -p tcp --dport 22 -j REDIRECT --to-ports 22"
+  iptables_unrule "-t nat -D PREROUTING -i ${AP_IFACE} -p udp --dport 53 -j REDIRECT --to-ports ${TOR_DNS_PORT}"
+  iptables_unrule "-t nat -D PREROUTING -i ${AP_IFACE} -p tcp --syn -j REDIRECT --to-ports ${TOR_TRANS_PORT}"
+  run_cmd "iptables-save > /etc/iptables/rules.v4"
+  [[ -f /etc/iptables.ipv4.nat ]] && run_cmd "iptables-save > /etc/iptables.ipv4.nat"
+  run_cmd "rm -f /etc/sysctl.d/99-tor-ap.conf"
+  run_cmd "sysctl --system"
+  echo "Uninstall complete"
+}
+
+iptables_unrule() {
+  local rule=$1
+  iptables ${rule/-D/-C} 2>/dev/null && run_cmd "iptables $rule" || true
+}
+
+main() {
+  require_root
+  check_bookworm
+  if ((UNINSTALL)); then
+    uninstall
+    return
+  fi
+  ensure_packages
+  ensure_sysctl
+  ensure_hotspot
+  ensure_torrc
+  ensure_iptables
+  start_services
+  summary
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add `setup-tor-ap.sh` to configure a Raspberry Pi as a Tor-routed Wi-Fi access point using NetworkManager and iptables.
- Provide comprehensive `README.md` with diagrams, setup instructions, and troubleshooting guidance.

## Testing
- `bash -n setup-tor-ap.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a5f6b69924832db706ccd82737fdcd