### PR TITLE
fix package installation newline issue

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -59,6 +59,7 @@ check_bookworm() {
 
 ensure_packages() {
   local packages=(tor iptables iptables-persistent qrencode network-manager)
+  local IFS=' '
   run_cmd "apt-get update"
   run_cmd "apt-get -y upgrade"
   run_cmd "apt-get -y install ${packages[*]}"


### PR DESCRIPTION
## Summary
- fix package installation to avoid newline separation that omitted dependencies

## Testing
- `bash setup-tor-ap.sh --dry-run` *(fails: This script supports Raspberry Pi OS Bookworm only)*
- `bash -n setup-tor-ap.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a60cc12a1c832d9b1a2b248ae940bb