### PR TITLE
Fix script PSK handling and document dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ graph LR
 NetworkManager creates a Wi-Fi hotspot on `wlan0` with the static gateway `192.168.220.1`. `iptables` PREROUTING rules redirect all TCP SYN packets and UDP DNS queries from clients into Tor's `TransPort` and `DNSPort`. Tor then handles outbound connections over `eth0`. No masquerading is needed because Tor manages the egress routing. Non-TCP protocols (other than UDP/53) are not proxied and will fail.
 
 ## Security Considerations
-- Change the default SSID and pre-shared key immediately.
+  - Use a strong pre-shared key; the SSID is fixed to `toratora`.
 - Keep the system updated.
 - Misconfiguration may expose traffic; Tor exit policies do not guarantee safety.
 - Logging in to personal accounts still reveals identity; do not route illegal traffic.
@@ -63,8 +63,16 @@ NetworkManager creates a Wi-Fi hotspot on `wlan0` with the static gateway `192.1
 
 ## Prerequisites
 - Raspberry Pi with Wi-Fi, SD card, power, and wired internet on `eth0`.
-- Raspberry Pi OS **Bookworm** (32- or 64-bit).
-- NetworkManager and Tor packages available via `apt`.
+  - Raspberry Pi OS **Bookworm** (32- or 64-bit).
+
+## Dependencies
+The setup script installs the following packages if they are not present:
+
+- `tor`
+- `iptables`
+- `iptables-persistent`
+- `qrencode`
+- `network-manager`
 
 ## Raspberry Pi Setup (from blank SD to first boot)
 1. Flash Raspberry Pi OS with Raspberry Pi Imager.
@@ -88,10 +96,10 @@ NetworkManager creates a Wi-Fi hotspot on `wlan0` with the static gateway `192.1
 Download or clone this repository, then:
 ```bash
 chmod +x setup-tor-ap.sh
-sudo SSID="MyTorAP" PSK="StrongPass123!" bash ./setup-tor-ap.sh
+sudo bash ./setup-tor-ap.sh <PSK>
 ```
 Environment variables:
-- `AP_IFACE`, `WAN_IFACE`, `AP_SUBNET`, `AP_GATEWAY`, `SSID`, `PSK`, `TOR_TRANS_PORT`, `TOR_DNS_PORT`
+- `AP_IFACE`, `WAN_IFACE`, `AP_SUBNET`, `AP_GATEWAY`, `TOR_TRANS_PORT`, `TOR_DNS_PORT`
 
 Flags:
 - `--dry-run` – show actions without making changes
@@ -135,7 +143,7 @@ Removes the NetworkManager hotspot, Tor configuration, NAT rules, and sysctl set
 - **Why not nftables?** Bookworm's `iptables-nft` provides compatibility; the script uses classic `iptables` for parity with common guides.
 - **Can I change the subnet?** Yes, set `AP_SUBNET`/`AP_GATEWAY` environment variables.
 - **Does it route UDP?** Only DNS (UDP/53). Other UDP protocols are unsupported through Tor TransPort.
-- **How do I customize SSID/PSK?** Set `SSID` and `PSK` before running the script.
+- **How do I customize SSID/PSK?** The SSID is always `toratora`; provide the desired PSK as an argument when running the script.
 
 ## Ethics & Legal
 Use Tor responsibly. Ensure that all traffic routed through this access point complies with local laws. The authors assume no liability for misuse.

--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -8,26 +8,45 @@ set -Eeuo pipefail
 IFS=$'\n\t'
 
 #===========================
-# Configuration (override via environment)
+# Configuration (override via environment except SSID)
 AP_IFACE=${AP_IFACE:-wlan0}
 WAN_IFACE=${WAN_IFACE:-eth0}
 AP_SUBNET=${AP_SUBNET:-192.168.220.0/24}
 AP_GATEWAY=${AP_GATEWAY:-192.168.220.1}
-SSID=${SSID:-TorAP}
-PSK=${PSK:-ChangeMe1234}
+SSID=toratora
 TOR_TRANS_PORT=${TOR_TRANS_PORT:-9040}
 TOR_DNS_PORT=${TOR_DNS_PORT:-53}
 #===========================
 
 DRY_RUN=0
 UNINSTALL=0
-for arg in "$@"; do
-  case "$arg" in
-    --dry-run) DRY_RUN=1 ;;
-    --uninstall) UNINSTALL=1 ;;
-    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+PSK=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --uninstall)
+      UNINSTALL=1
+      shift
+      ;;
+    *)
+      if [[ -z $PSK ]]; then
+        PSK=$1
+        shift
+      else
+        echo "Unknown option: $1" >&2
+        exit 1
+      fi
+      ;;
   esac
 done
+
+if (( ! UNINSTALL )) && [[ -z $PSK ]]; then
+  echo "Usage: $0 [--dry-run] [--uninstall] <psk>" >&2
+  exit 1
+fi
 
 run_cmd() {
   echo "+ $*"


### PR DESCRIPTION
## Summary
- Fix setup script to always broadcast SSID `toratora` and take the Wi-Fi password as a required argument
- Document required packages and update usage instructions in README

## Testing
- `bash -n setup-tor-ap.sh`
- `./setup-tor-ap.sh --dry-run mysecretpsk` *(fails: This script supports Raspberry Pi OS Bookworm only)*


------
https://chatgpt.com/codex/tasks/task_e_68a60ea2cc9c832d880e822db7c8f7e8