### PR TITLE
Handle inactive Tor service by cleaning NAT rules

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -148,6 +148,14 @@ iptables_rule() {
   fi
 }
 
+remove_tor_iptables() {
+  iptables_unrule "-t nat -D PREROUTING -i ${AP_IFACE} -p tcp --dport 22 -j REDIRECT --to-ports 22"
+  iptables_unrule "-t nat -D PREROUTING -i ${AP_IFACE} -p udp --dport 53 -j REDIRECT --to-ports ${TOR_DNS_PORT}"
+  iptables_unrule "-t nat -D PREROUTING -i ${AP_IFACE} -p tcp --syn -j REDIRECT --to-ports ${TOR_TRANS_PORT}"
+  run_cmd "iptables-save > /etc/iptables/rules.v4"
+  [[ -f /etc/iptables.ipv4.nat ]] && run_cmd "iptables-save > /etc/iptables.ipv4.nat"
+}
+
 start_services() {
   run_cmd "systemctl enable --now tor"
   for i in {1..30}; do
@@ -157,6 +165,10 @@ start_services() {
     fi
     sleep 1
   done
+  if ! systemctl is-active --quiet tor; then
+    echo "Tor service inactive; removing Tor NAT rules."
+    remove_tor_iptables
+  fi
 }
 
 summary() {


### PR DESCRIPTION
## Summary
- Remove Tor-specific NAT rules when the Tor service isn't active
- Add helper for clearing iptables redirects

## Testing
- `bash -n setup-tor-ap.sh`
- `shellcheck setup-tor-ap.sh` (warnings: SC2294 SC1091 SC2086 SC2034 SC2028 SC2015)


------
https://chatgpt.com/codex/tasks/task_e_68a619471698832d8cae6143dfacb169