### PR TITLE
Add post-setup verification for Tor AP setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Backups: `/etc/tor/torrc.bak` is created once. Sysctl and iptables files are mod
 Services: enables `tor` and restores iptables at boot.
 
 ## Verification Checklist
+After setup completes, the script automatically checks that the hotspot, Tor
+service, iptables rules, and IP forwarding are working. You can also manually
+confirm:
 - `nmcli dev` shows hotspot active on `wlan0` with IP `192.168.220.1`.
 - `sudo systemctl status tor` is “active (running)”.
 - `sudo iptables -t nat -L -n -v` lists the three redirect rules.


### PR DESCRIPTION
## Summary
- add verification function checking hotspot, Tor service, iptables rules, and IP forwarding
- call verification after setup completes
- document automatic verification in README

## Testing
- `bash -n setup-tor-ap.sh`
- `shellcheck setup-tor-ap.sh` *(fails: SC2294, SC1091, SC2086, SC2034, SC2028, SC2015)*

------
https://chatgpt.com/codex/tasks/task_e_68a61bebf90c832da3299bb2bfdf3367