### PR TITLE
Prevent spinner kill from aborting setup script

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -100,7 +100,8 @@ run_cmd() {
   local spin_pid=$!
   wait $cmd_pid
   local status=$?
-  kill $spin_pid 2>/dev/null; wait $spin_pid 2>/dev/null
+  kill $spin_pid 2>/dev/null || true
+  wait $spin_pid 2>/dev/null || true
   if ((status)); then
     alert "Command failed: $*"
     return 1


### PR DESCRIPTION
## Summary
- prevent `set -e` from exiting when stopping the spinner in `run_cmd`

## Testing
- `bash -n setup-tor-ap.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a62cd6ef7c832db3ca6788071adfd2