### PR TITLE
fix: replace undefined RESET variable in setup banner

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -31,7 +31,7 @@ banner() {
     ██║   ╚██████╔╝██║  ██║██║  ██║   ██║   ╚██████╔╝██║  ██║██║  ██║
     ╚═╝    ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝   ╚═╝    ╚═════╝ ╚═╝  ╚═╝╚═╝  ╚═╝
 EOF
-  echo -e "${RESET}${RED}${BOLD}>>> TOR AP CONFIGURATION <<<${RESET}"
+  echo -e "${NC}${RED}${BOLD}>>> TOR AP CONFIGURATION <<<${NC}"
   divider
 }
 


### PR DESCRIPTION
## Summary
- replace unbound RESET variable in banner with NC

## Testing
- `bash -n setup-tor-ap.sh`
- `shellcheck setup-tor-ap.sh`

------
https://chatgpt.com/codex/tasks/task_e_68a63b0c291c832db96fff4305c5fee8