### PR TITLE
Print Wi-Fi QR code in mission summary

### DIFF
--- a/setup-tor-ap.sh
+++ b/setup-tor-ap.sh
@@ -222,6 +222,10 @@ summary() {
   info "Access Point IP: $AP_GATEWAY"
   systemctl is-active --quiet tor && tor_status="active" || tor_status="inactive"
   info "Tor service: $tor_status"
+  if command -v qrencode &>/dev/null; then
+    info "Wi-Fi access QR:"
+    qrencode -t ansiutf8 "WIFI:S:${SSID};T:WPA;P:${PSK};;" || true
+  fi
   info "iptables NAT table:"
   iptables -t nat -L -n -v | sed -n '1,120p'
 }


### PR DESCRIPTION
## Summary
- Print hotspot QR code during mission summary for easy client connection

## Testing
- `shellcheck setup-tor-ap.sh`
- `AP_IFACE=lo bash -c 'source <(sed '\''$d'\'' setup-tor-ap.sh) --dry-run "Password123!"; summary'` *(fails: iptables: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68a63d23cc38832db3be4d0278333caa