### PR TITLE
Add optional Unicorn HAT status display

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ is idempotent, reversible, and uses NetworkManager for Wi-Fi configuration.
 - Transparent Tor routing (TransPort/DNSPort)
 - Idempotent & reversible configuration
 - Works on Raspberry Pi OS Bookworm
+- Optional Unicorn HAT status display
 
 ## Architecture
 
@@ -112,6 +113,13 @@ After setup completes, the script automatically checks that the hotspot, Tor ser
 - On a client connected to the AP:
   - DNS queries resolve.
   - `curl https://check.torproject.org/` shows Tor usage.
+
+## Optional Status Matrix
+If a Pimoroni Unicorn HAT or Unicorn HAT HD is attached you can run
+`status_matrix_service.py` to display Pi health, Tor status, access point
+status, and traffic levels. The service reads settings from
+`status_matrix.yaml`. Set `use_unicorn_hat: false` in that file if the
+hardware is not present.
 
 ## Troubleshooting
 - **Tor bind errors**: ensure the hotspot is up before Tor starts; the script retries for 30s.

--- a/README_StatusMatrix.md
+++ b/README_StatusMatrix.md
@@ -19,7 +19,8 @@ sudo apt install python3-yaml
 ```
 
 2. Copy files to desired directory, e.g. `/home/pi`.
-3. Adjust `status_matrix.yaml` if required.
+3. Adjust `status_matrix.yaml` if required. Set `use_unicorn_hat: false`
+   to run the service without the hardware.
 
 ## Running
 
@@ -28,6 +29,7 @@ python3 status_matrix_service.py --config status_matrix.yaml
 ```
 
 Use `--demo` to run a simple colour cycle demonstration. `--print-debug` dumps collected metrics once per second.
+Add `--no-hat` to run without Unicorn HAT output.
 
 ## Service
 

--- a/status_matrix.py
+++ b/status_matrix.py
@@ -42,6 +42,7 @@ class DummyUnicorn:
 @dataclass
 class Config:
     device: str = "auto"
+    use_unicorn_hat: bool = True
     iface: str = "auto"
     frame_ms: int = 80
     brightness: float = 0.35
@@ -81,6 +82,11 @@ class StatusMatrix:
 
     def _init_device(self):
         self.hd = False
+        if not self.config.use_unicorn_hat:
+            self.uh = DummyUnicorn()
+            self.uh.brightness(self.config.brightness)
+            return
+
         uh = None
         if self.config.device in ("auto", "unicorn_hat"):
             try:  # pragma: no cover - requires hardware

--- a/status_matrix.yaml
+++ b/status_matrix.yaml
@@ -1,4 +1,5 @@
 device: auto
+use_unicorn_hat: true
 iface: auto
 frame_ms: 80
 brightness: 0.35

--- a/status_matrix_service.py
+++ b/status_matrix_service.py
@@ -30,11 +30,15 @@ def main():
     parser.add_argument('--config', default='status_matrix.yaml')
     parser.add_argument('--brightness', type=float)
     parser.add_argument('--iface')
+    parser.add_argument('--no-hat', action='store_true',
+                        help='run without Unicorn HAT output')
     parser.add_argument('--demo', action='store_true')
     parser.add_argument('--print-debug', action='store_true')
     args = parser.parse_args()
-
     sm = StatusMatrix(config_path=args.config)
+    if args.no_hat:
+        sm.config.use_unicorn_hat = False
+        sm._init_device()
     if args.brightness is not None:
         sm.uh.brightness(args.brightness)
     if args.iface:

--- a/tests/test_status_matrix.py
+++ b/tests/test_status_matrix.py
@@ -17,6 +17,12 @@ def test_traffic_bucket():
     assert level == 4  # above highest bucket
 
 
+def test_disabled_unicorn_hat_uses_dummy():
+    cfg = Config(use_unicorn_hat=False)
+    sm = StatusMatrix(config=cfg)
+    assert isinstance(sm.uh, status_matrix.DummyUnicorn)
+
+
 def test_hd_slice():
     cfg = Config()
     sm = StatusMatrix(config=cfg)


### PR DESCRIPTION
## Summary
- allow status matrix to be disabled by adding a `use_unicorn_hat` flag and dummy display fallback
- expose a `--no-hat` command line option to run the status matrix service without hardware
- document optional Unicorn HAT usage and configuration in README files

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab1de60004832d954f65390b6222e4